### PR TITLE
Show button "copy to clipboard" below "manual link".

### DIFF
--- a/web/login.html
+++ b/web/login.html
@@ -15,12 +15,23 @@
     <p>Scan the QR code with your Delta Chat app to authenticate yourself with your email address!</p>
     <div id="loading">Loading</div>
     <img class="qr hidden" id="qr" src="">
-    <br>
     <a class="manual-link hidden" href='#' id="qr_content">Manual link</a>
+    <a class="manual-link clipboard-link hidden" href='#' id="copy-to-clipboard">Copy data to clipboard</a>
+    <input style="position: absolute; left: -9999px" readonly='true' id="qr-data" value="">
     <div id="error"></div>
   </main>
   <script>
     const D = id => document.getElementById(id)
+    function copyDataToClipboard(ev) {
+      ev.preventDefault()
+      var elem = D('qr-data')
+      elem.focus()
+      elem.select()
+      document.execCommand("copy")
+    }
+
+    D('copy-to-clipboard').addEventListener("click", copyDataToClipboard)
+
     function requestQR() {
       var req = new XMLHttpRequest()
       req.open("GET", "/requestQR")
@@ -31,11 +42,13 @@
           if(data.qr_code_data_url) {
             D('qr').src = data.qr_code_data_url
             D('qr_content').href = data.qr_data
+            D('qr-data').value = data.qr_data
           } else {
             throw new Error("Data is undefined")
           }
           D('qr').classList.remove('hidden')
           D('qr_content').classList.remove('hidden')
+          D('copy-to-clipboard').classList.remove('hidden')
           D('loading').classList.add('hidden')
         } catch (error) {
           D('error').innerHTML = `Couldn't get the QR code, please reload the page: ${this.responseText}`

--- a/web/styles.css
+++ b/web/styles.css
@@ -47,8 +47,7 @@ h1 {
 
 a.manual-link {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 1em auto;
     width: max-content;
     font-family: sans-serif;
     background-color:#444;
@@ -56,6 +55,10 @@ a.manual-link {
     border-radius: 5px;
     padding: 10px;
     text-decoration: none;
+}
+
+a.clipboard-link {
+    background-color: #bbb;
 }
 
 p {


### PR DESCRIPTION
Currently, no one can properly use the "Manual link" anyway (DC Desktop doesn't register on the URI-scheme yet, and this might still take a while to work on all platforms).

But DC-Desktop will soon be able to scan QR-codes, and interpret pasted QR-data. For that copying the QR-data from the login page into the user's clipboard makes sense.